### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,9 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
+#if !os(Linux)
 import CoreGraphics
+#endif
 
 let package = Package(
     name: "SwiftMath",


### PR DESCRIPTION
Allow `package-dump` on Linux

I wanted to [add your package to the Swift Package Index](https://github.com/SwiftPackageIndex/PackageList/issues/4474) but because we run `swift package dump-package` on Linux in our package verification it fails due to the `import CoreGraphics` line.