### PR TITLE
Add thread safety for fonts cache via read-write lock in MTFontManager

### DIFF
--- a/Sources/SwiftMath/MathRender/MTFontManager.swift
+++ b/Sources/SwiftMath/MathRender/MTFontManager.swift
@@ -22,9 +22,10 @@ public class MTFontManager {
     }
 
     public init() { }
-    
+
+    @RWLocked
     var nameToFontMap = [String: MTFont]()
-    
+
     public func font(withName name:String, size:CGFloat) -> MTFont? {
         var f = self.nameToFontMap[name]
         if f == nil {

--- a/Sources/SwiftMath/MathRender/RWLock.swift
+++ b/Sources/SwiftMath/MathRender/RWLock.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+final class RWLock {
+    init() {
+        pthread_rwlock_init(&lock, nil)
+    }
+
+    deinit {
+        pthread_rwlock_destroy(&lock)
+    }
+
+    func read<T>(_ block: () -> T) -> T {
+        pthread_rwlock_rdlock(&lock)
+        defer { pthread_rwlock_unlock(&lock) }
+        return block()
+    }
+
+    func readWrite<T>(_ block: () -> T) -> T {
+        pthread_rwlock_wrlock(&lock)
+        defer { pthread_rwlock_unlock(&lock) }
+        return block()
+    }
+
+    private var lock = pthread_rwlock_t()
+}
+
+@propertyWrapper
+struct RWLocked<T> {
+    init(wrappedValue: T) {
+        value = wrappedValue
+    }
+
+    var wrappedValue: T {
+        get {
+            lock.read {
+                value
+            }
+        }
+        set {
+            lock.readWrite {
+                value = newValue
+            }
+        }
+    }
+
+    @discardableResult
+    mutating func readWrite(_ block: (inout T) -> Void) -> (oldValue: T, newValue: T) {
+        lock.readWrite {
+            let old = value
+            block(&value)
+            return (old, value)
+        }
+    }
+
+    private var value: T
+    private let lock = RWLock()
+}
+


### PR DESCRIPTION
Hello!
We found at our app that in a multithreaded environment MTFontManager is getting crashed when we ask for fonts from different places. 
And since we don't have access to shared MTFontManager we decided to open PR with adding thread-safety for this property

Thanks