### PR TITLE
Add layout info to MathImage

### DIFF
--- a/Sources/SwiftMath/MathBundle/MathImage.swift
+++ b/Sources/SwiftMath/MathBundle/MathImage.swift
@@ -46,7 +46,16 @@ extension MathImage {
         CGSize(width: displayList.width + contentInsets.left + contentInsets.right,
                height: displayList.ascent + displayList.descent + contentInsets.top + contentInsets.bottom)
     }
-    public mutating func asImage() -> (NSError?, MTImage?) {
+    public struct LayoutInfo {
+        public var ascent: CGFloat = 0
+        public var descent: CGFloat = 0
+
+        public init(ascent: CGFloat, descent: CGFloat) {
+            self.ascent = ascent
+            self.descent = descent
+        }
+    }
+    public mutating func asImage() -> (NSError?, MTImage?, LayoutInfo?) {
         func layoutImage(size: CGSize, displayList: MTMathListDisplay) {
             var textX = CGFloat(0)
             switch self.textAlignment {
@@ -69,7 +78,7 @@ extension MathImage {
 
         guard let mathList = MTMathListBuilder.build(fromString: latex, error: &error), error == nil,
               let displayList = MTTypesetter.createLineForMathList(mathList, font: mtfont, style: currentStyle) else {
-            return (error, nil)
+            return (error, nil, nil)
         }
 
         intrinsicContentSize = intrinsicContentSize(displayList)
@@ -86,7 +95,7 @@ extension MathImage {
                 displayList.draw(rendererContext.cgContext)
                 rendererContext.cgContext.restoreGState()
             }
-            return (nil, image)
+            return (nil, image, LayoutInfo(ascent: displayList.ascent, descent: displayList.descent))
         #endif
         #if os(macOS)
             let image = NSImage(size: size, flipped: false) { bounds in
@@ -96,7 +105,7 @@ extension MathImage {
                 context.restoreGState()
                 return true
             }
-            return (nil, image)
+            return (nil, image, LayoutInfo(ascent: displayList.ascent, descent: displayList.descent))
         #endif
     }
 }

--- a/Tests/SwiftMathTests/MathImageTests.swift
+++ b/Tests/SwiftMathTests/MathImageTests.swift
@@ -21,6 +21,7 @@ final class MathImageTests: XCTestCase {
         let result = SwiftMathImageResult.useMathImage(latex: latex, font: mathfont, fontSize: fontsize)
         XCTAssertNil(result.error)
         XCTAssertNotNil(result.image)
+        XCTAssertNotNil(result.layoutInfo)
         if result.error == nil, let image = result.image, let imageData = image.pngData() {
             safeImage(fileName: "test", pngData: imageData)
             let fileUrl = URL(fileURLWithPath: NSTemporaryDirectory())
@@ -38,6 +39,7 @@ final class MathImageTests: XCTestCase {
                 result = SwiftMathImageResult.useMathImage(latex: latex, font: mathfont, fontSize: fontsize)
                 XCTAssertNil(result.error)
                 XCTAssertNotNil(result.image)
+                XCTAssertNotNil(result.layoutInfo)
                 if result.error == nil, let image = result.image, let imageData = image.pngData() {
                     safeImage(fileName: "\(caseNumber)", pngData: imageData)
                     //let fileUrl = URL(fileURLWithPath: NSTemporaryDirectory())
@@ -87,6 +89,7 @@ final class MathImageTests: XCTestCase {
             let result = SwiftMathImageResult.useMathImage(latex: latex, font: mathfont, fontSize: fontsize)
             XCTAssertNil(result.error)
             XCTAssertNotNil(result.image)
+            XCTAssertNotNil(result.layoutInfo)
             if result.error == nil, let image = result.image, let imageData = image.pngData() {
                 self?.safeImage(fileName: "\(count)", pngData: imageData)
             }
@@ -114,6 +117,7 @@ final class MathImageTests: XCTestCase {
 public struct SwiftMathImageResult {
     let error: NSError?
     let image: MTImage?
+    let layoutInfo: MathImage.LayoutInfo?
 }
 extension SwiftMathImageResult {
     public static func useMTMathImage(latex: String, font: MathFont, fontSize: CGFloat, textColor: MTColor = MTColor.black) -> SwiftMathImageResult {
@@ -123,7 +127,7 @@ extension SwiftMathImageResult {
                                     labelMode: .text, textAlignment: alignment)
         formatter.font = font.mtfont(size: fontSize)
         let (error, image) = formatter.asImage()
-        return SwiftMathImageResult(error: error, image: image)
+        return SwiftMathImageResult(error: error, image: image, layoutInfo: nil)
     }
     public static func useMathImage(latex: String, font: MathFont, fontSize: CGFloat, textColor: MTColor = MTColor.black) -> SwiftMathImageResult {
         let alignment = MTTextAlignment.left
@@ -131,8 +135,8 @@ extension SwiftMathImageResult {
                                   textColor: textColor,
                                   labelMode: .text, textAlignment: alignment)
         formatter.font = font
-        let (error, image) = formatter.asImage()
-        return SwiftMathImageResult(error: error, image: image)
+        let (error, image, layoutInfo) = formatter.asImage()
+        return SwiftMathImageResult(error: error, image: image, layoutInfo: layoutInfo)
     }
 }
 #if os(macOS)


### PR DESCRIPTION
This makes it possible to align images generated by `MathImage` alongside text, in an `AttributedString` for example.

I've only added the functionality to `MathImage` but I can also add it to `MTMathImage` if you'd like.