### PR TITLE
Fix a crash at cell spacer insertion loop

### DIFF
--- a/Sources/SwiftMath/MathRender/MTMathAtomFactory.swift
+++ b/Sources/SwiftMath/MathRender/MTMathAtomFactory.swift
@@ -848,7 +848,7 @@ public class MTMathAtomFactory {
                 let spacer = MTMathAtom(type: .ordinary, value: "")
                 
                 for i in 0..<table.cells.count {
-                    if table.cells[i].count >= 1 {
+                    if table.cells[i].count >= 2 {
                         table.cells[i][1].insert(spacer, at: 0)
                     }
                 }


### PR DESCRIPTION
example crash:

```
struct ContentView: View {
    @State var text: String = #"""
    \\[
    \begin{align*}
    \text{result.r} &= 1.0 \times 0.5 + 0.0 \times (1 - 0.5) = 0.5 \\
    \text{result.g} &= 0.0 \times 0.5 + 0.0 \times (1 - 0.5) = 0.0 \\
    \text{result.b} &= 0.0 \times 0.5 + 1.0 \times (1 - 0.5) = 0.5 \\
    \text{result.a} &= 0.5 \times 0.5 + 1.0 \times (1 - 0.5) = 0.75 \\
    \end{align*}
    \\]
    """#
    var latext: String {
        text
        .replacingOccurrences(of: "\\implies", with: "\\Rightarrow")
        .replacingOccurrences(of: "\\begin{align}", with: "\\begin{aligned}")
        .replacingOccurrences(of: "\\end{align}", with: "\\end{aligned}")
        .replacingOccurrences(of: "\\begin{align*}", with: "\\begin{aligned}")
        .replacingOccurrences(of: "\\end{align*}", with: "\\end{aligned}")
        .replacingOccurrences(of: "\\begin{cases}", with: "\\left\\{\\begin{matrix}")
        .replacingOccurrences(of: "\\end{cases}", with: "\\end{matrix}\\right.")
    }
    
    var body: some View {
        VStack {
            TextEditor(text: $text)
            Divider()
            MathView(equation: latext)
        }
        .padding()
    }
}
```