### PR TITLE
49: mathColor was used instead of mathColorbox

### DIFF
--- a/Sources/SwiftMath/MathRender/MTMathListBuilder.swift
+++ b/Sources/SwiftMath/MathRender/MTMathListBuilder.swift
@@ -617,7 +617,7 @@ public struct MTMathListBuilder {
             if color == nil {
                 return nil;
             }
-            mathColor.colorString = color!
+            mathColorbox.colorString = color!
             mathColorbox.innerList = self.buildInternal(true)
             return mathColorbox
         } else {


### PR DESCRIPTION
Fixed wrong reference, mathColor was used instead of mathColorbox
This PR solves issue #49