### PR TITLE
feat: add Priority 1 symbols and negated relations

### DIFF
--- a/Sources/SwiftMath/MathRender/MTMathAtomFactory.swift
+++ b/Sources/SwiftMath/MathRender/MTMathAtomFactory.swift
@@ -178,8 +178,7 @@ public class MTMathAtomFactory {
         "varrho" : MTMathAtom(type: .ordinary, value: "\u{0001D71A}"),
         "varpi" : MTMathAtom(type: .ordinary, value: "\u{0001D71B}"),
         "varkappa" : MTMathAtom(type: .ordinary, value: "\u{03F0}"),
-        "digamma" : MTMathAtom(type: .variable, value: "\u{03DD}"),
-        "Digamma" : MTMathAtom(type: .variable, value: "\u{03DC}"),
+        // Note: digamma (U+03DD) and Digamma (U+03DC) are not supported by Latin Modern Math font
 
         // Capital greek characters
         "Gamma" : MTMathAtom(type: .variable, value: "\u{0393}"),
@@ -274,6 +273,67 @@ public class MTMathAtomFactory {
         "bowtie" : MTMathAtom(type: .relation, value: "\u{22C8}"),
         "perp" : MTMathAtom(type: .relation, value: "\u{27C2}"),
         "implies" : MTMathAtom(type: .relation, value: "\u{27F9}"),
+
+        // Negated relations (amssymb)
+        // Inequality negations
+        "nless" : MTMathAtom(type: .relation, value: "\u{226E}"),
+        "ngtr" : MTMathAtom(type: .relation, value: "\u{226F}"),
+        "nleq" : MTMathAtom(type: .relation, value: "\u{2270}"),
+        "ngeq" : MTMathAtom(type: .relation, value: "\u{2271}"),
+        "nleqslant" : MTMathAtom(type: .relation, value: "\u{2A87}"),
+        "ngeqslant" : MTMathAtom(type: .relation, value: "\u{2A88}"),
+        "lneq" : MTMathAtom(type: .relation, value: "\u{2A87}"),
+        "gneq" : MTMathAtom(type: .relation, value: "\u{2A88}"),
+        "lneqq" : MTMathAtom(type: .relation, value: "\u{2268}"),
+        "gneqq" : MTMathAtom(type: .relation, value: "\u{2269}"),
+        "lnsim" : MTMathAtom(type: .relation, value: "\u{22E6}"),
+        "gnsim" : MTMathAtom(type: .relation, value: "\u{22E7}"),
+        "lnapprox" : MTMathAtom(type: .relation, value: "\u{2A89}"),
+        "gnapprox" : MTMathAtom(type: .relation, value: "\u{2A8A}"),
+        // Ordering negations
+        "nprec" : MTMathAtom(type: .relation, value: "\u{2280}"),
+        "nsucc" : MTMathAtom(type: .relation, value: "\u{2281}"),
+        "npreceq" : MTMathAtom(type: .relation, value: "\u{22E0}"),
+        "nsucceq" : MTMathAtom(type: .relation, value: "\u{22E1}"),
+        "precneqq" : MTMathAtom(type: .relation, value: "\u{2AB5}"),
+        "succneqq" : MTMathAtom(type: .relation, value: "\u{2AB6}"),
+        "precnsim" : MTMathAtom(type: .relation, value: "\u{22E8}"),
+        "succnsim" : MTMathAtom(type: .relation, value: "\u{22E9}"),
+        "precnapprox" : MTMathAtom(type: .relation, value: "\u{2AB9}"),
+        "succnapprox" : MTMathAtom(type: .relation, value: "\u{2ABA}"),
+        // Similarity/congruence negations
+        "nsim" : MTMathAtom(type: .relation, value: "\u{2241}"),
+        "ncong" : MTMathAtom(type: .relation, value: "\u{2247}"),
+        "nmid" : MTMathAtom(type: .relation, value: "\u{2224}"),
+        "nshortmid" : MTMathAtom(type: .relation, value: "\u{2224}"),
+        "nparallel" : MTMathAtom(type: .relation, value: "\u{2226}"),
+        "nshortparallel" : MTMathAtom(type: .relation, value: "\u{2226}"),
+        // Set relation negations
+        "nsubseteq" : MTMathAtom(type: .relation, value: "\u{2288}"),
+        "nsupseteq" : MTMathAtom(type: .relation, value: "\u{2289}"),
+        "subsetneq" : MTMathAtom(type: .relation, value: "\u{228A}"),
+        "supsetneq" : MTMathAtom(type: .relation, value: "\u{228B}"),
+        "subsetneqq" : MTMathAtom(type: .relation, value: "\u{2ACB}"),
+        "supsetneqq" : MTMathAtom(type: .relation, value: "\u{2ACC}"),
+        "varsubsetneq" : MTMathAtom(type: .relation, value: "\u{228A}"),
+        "varsupsetneq" : MTMathAtom(type: .relation, value: "\u{228B}"),
+        "varsubsetneqq" : MTMathAtom(type: .relation, value: "\u{2ACB}"),
+        "varsupsetneqq" : MTMathAtom(type: .relation, value: "\u{2ACC}"),
+        "notni" : MTMathAtom(type: .relation, value: "\u{220C}"),
+        "nni" : MTMathAtom(type: .relation, value: "\u{220C}"),
+        // Triangle negations
+        "ntriangleleft" : MTMathAtom(type: .relation, value: "\u{22EA}"),
+        "ntriangleright" : MTMathAtom(type: .relation, value: "\u{22EB}"),
+        "ntrianglelefteq" : MTMathAtom(type: .relation, value: "\u{22EC}"),
+        "ntrianglerighteq" : MTMathAtom(type: .relation, value: "\u{22ED}"),
+        // Turnstile negations
+        "nvdash" : MTMathAtom(type: .relation, value: "\u{22AC}"),
+        "nvDash" : MTMathAtom(type: .relation, value: "\u{22AD}"),
+        "nVdash" : MTMathAtom(type: .relation, value: "\u{22AE}"),
+        "nVDash" : MTMathAtom(type: .relation, value: "\u{22AF}"),
+        // Square subset negations
+        "nsqsubseteq" : MTMathAtom(type: .relation, value: "\u{22E2}"),
+        "nsqsupseteq" : MTMathAtom(type: .relation, value: "\u{22E3}"),
 
         // operators
         "times" : MTMathAtomFactory.times(),

--- a/Tests/SwiftMathTests/MTMathListBuilderTests.swift
+++ b/Tests/SwiftMathTests/MTMathListBuilderTests.swift
@@ -2740,7 +2740,8 @@ final class MTMathListBuilderTests: XCTestCase {
     // MARK: - Priority 1 Symbol Tests
 
     func testGreekVariants() throws {
-        let variants = ["varkappa", "digamma", "Digamma", "varepsilon", "vartheta", "varpi", "varrho", "varsigma", "varphi"]
+        // Note: digamma/Digamma (U+03DD/U+03DC) removed - not supported by Latin Modern Math font
+        let variants = ["varkappa", "varepsilon", "vartheta", "varpi", "varrho", "varsigma", "varphi"]
 
         for variant in variants {
             var error: NSError? = nil
@@ -2927,6 +2928,179 @@ final class MTMathListBuilderTests: XCTestCase {
         let list = MTMathListBuilder.build(fromString: str)!
         let latex = MTMathListBuilder.mathListToString(list)
         XCTAssertEqual(latex, "\\mathbb{R}", "Should round-trip correctly")
+    }
+
+    // MARK: - Negated Relations Tests
+
+    func testNegatedInequalityRelations() throws {
+        let symbols: [(command: String, unicode: String)] = [
+            ("nless", "\u{226E}"),      // ≮
+            ("ngtr", "\u{226F}"),       // ≯
+            ("nleq", "\u{2270}"),       // ≰
+            ("ngeq", "\u{2271}"),       // ≱
+            ("nleqslant", "\u{2A87}"),  // ⪇
+            ("ngeqslant", "\u{2A88}"),  // ⪈
+            ("lneq", "\u{2A87}"),       // ⪇
+            ("gneq", "\u{2A88}"),       // ⪈
+            ("lneqq", "\u{2268}"),      // ≨
+            ("gneqq", "\u{2269}"),      // ≩
+            ("lnsim", "\u{22E6}"),      // ⋦
+            ("gnsim", "\u{22E7}"),      // ⋧
+            ("lnapprox", "\u{2A89}"),   // ⪉
+            ("gnapprox", "\u{2A8A}"),   // ⪊
+        ]
+
+        for (command, unicode) in symbols {
+            var error: NSError? = nil
+            let str = "\\\(command)"
+            let list = MTMathListBuilder.build(fromString: str, error: &error)
+
+            let unwrappedList = try XCTUnwrap(list, "Should parse \\\(command)")
+            XCTAssertNil(error, "Should not error on \\\(command)")
+            XCTAssertEqual(unwrappedList.atoms.count, 1)
+            XCTAssertEqual(unwrappedList.atoms[0].type, .relation)
+            XCTAssertEqual(unwrappedList.atoms[0].nucleus, unicode, "\\\(command) should have unicode \(unicode)")
+        }
+    }
+
+    func testNegatedOrderingRelations() throws {
+        let symbols: [(command: String, unicode: String)] = [
+            ("nprec", "\u{2280}"),       // ⊀
+            ("nsucc", "\u{2281}"),       // ⊁
+            ("npreceq", "\u{22E0}"),     // ⋠
+            ("nsucceq", "\u{22E1}"),     // ⋡
+            ("precneqq", "\u{2AB5}"),    // ⪵
+            ("succneqq", "\u{2AB6}"),    // ⪶
+            ("precnsim", "\u{22E8}"),    // ⋨
+            ("succnsim", "\u{22E9}"),    // ⋩
+            ("precnapprox", "\u{2AB9}"), // ⪹
+            ("succnapprox", "\u{2ABA}"), // ⪺
+        ]
+
+        for (command, unicode) in symbols {
+            var error: NSError? = nil
+            let str = "\\\(command)"
+            let list = MTMathListBuilder.build(fromString: str, error: &error)
+
+            let unwrappedList = try XCTUnwrap(list, "Should parse \\\(command)")
+            XCTAssertNil(error, "Should not error on \\\(command)")
+            XCTAssertEqual(unwrappedList.atoms.count, 1)
+            XCTAssertEqual(unwrappedList.atoms[0].type, .relation)
+            XCTAssertEqual(unwrappedList.atoms[0].nucleus, unicode, "\\\(command) should have unicode \(unicode)")
+        }
+    }
+
+    func testNegatedSimilarityRelations() throws {
+        let symbols: [(command: String, unicode: String)] = [
+            ("nsim", "\u{2241}"),           // ≁
+            ("ncong", "\u{2247}"),          // ≇
+            ("nmid", "\u{2224}"),           // ∤
+            ("nshortmid", "\u{2224}"),      // ∤
+            ("nparallel", "\u{2226}"),      // ∦
+            ("nshortparallel", "\u{2226}"), // ∦
+        ]
+
+        for (command, unicode) in symbols {
+            var error: NSError? = nil
+            let str = "\\\(command)"
+            let list = MTMathListBuilder.build(fromString: str, error: &error)
+
+            let unwrappedList = try XCTUnwrap(list, "Should parse \\\(command)")
+            XCTAssertNil(error, "Should not error on \\\(command)")
+            XCTAssertEqual(unwrappedList.atoms.count, 1)
+            XCTAssertEqual(unwrappedList.atoms[0].type, .relation)
+            XCTAssertEqual(unwrappedList.atoms[0].nucleus, unicode, "\\\(command) should have unicode \(unicode)")
+        }
+    }
+
+    func testNegatedSetRelations() throws {
+        let symbols: [(command: String, unicode: String)] = [
+            ("nsubseteq", "\u{2288}"),     // ⊈
+            ("nsupseteq", "\u{2289}"),     // ⊉
+            ("subsetneq", "\u{228A}"),     // ⊊
+            ("supsetneq", "\u{228B}"),     // ⊋
+            ("subsetneqq", "\u{2ACB}"),    // ⫋
+            ("supsetneqq", "\u{2ACC}"),    // ⫌
+            ("varsubsetneq", "\u{228A}"),  // ⊊ (variant)
+            ("varsupsetneq", "\u{228B}"),  // ⊋ (variant)
+            ("varsubsetneqq", "\u{2ACB}"), // ⫋ (variant)
+            ("varsupsetneqq", "\u{2ACC}"), // ⫌ (variant)
+            ("notni", "\u{220C}"),         // ∌
+            ("nni", "\u{220C}"),           // ∌
+        ]
+
+        for (command, unicode) in symbols {
+            var error: NSError? = nil
+            let str = "\\\(command)"
+            let list = MTMathListBuilder.build(fromString: str, error: &error)
+
+            let unwrappedList = try XCTUnwrap(list, "Should parse \\\(command)")
+            XCTAssertNil(error, "Should not error on \\\(command)")
+            XCTAssertEqual(unwrappedList.atoms.count, 1)
+            XCTAssertEqual(unwrappedList.atoms[0].type, .relation)
+            XCTAssertEqual(unwrappedList.atoms[0].nucleus, unicode, "\\\(command) should have unicode \(unicode)")
+        }
+    }
+
+    func testNegatedTriangleRelations() throws {
+        let symbols: [(command: String, unicode: String)] = [
+            ("ntriangleleft", "\u{22EA}"),     // ⋪
+            ("ntriangleright", "\u{22EB}"),    // ⋫
+            ("ntrianglelefteq", "\u{22EC}"),   // ⋬
+            ("ntrianglerighteq", "\u{22ED}"),  // ⋭
+        ]
+
+        for (command, unicode) in symbols {
+            var error: NSError? = nil
+            let str = "\\\(command)"
+            let list = MTMathListBuilder.build(fromString: str, error: &error)
+
+            let unwrappedList = try XCTUnwrap(list, "Should parse \\\(command)")
+            XCTAssertNil(error, "Should not error on \\\(command)")
+            XCTAssertEqual(unwrappedList.atoms.count, 1)
+            XCTAssertEqual(unwrappedList.atoms[0].type, .relation)
+            XCTAssertEqual(unwrappedList.atoms[0].nucleus, unicode, "\\\(command) should have unicode \(unicode)")
+        }
+    }
+
+    func testNegatedTurnstileRelations() throws {
+        let symbols: [(command: String, unicode: String)] = [
+            ("nvdash", "\u{22AC}"),  // ⊬
+            ("nvDash", "\u{22AD}"),  // ⊭
+            ("nVdash", "\u{22AE}"),  // ⊮
+            ("nVDash", "\u{22AF}"),  // ⊯
+        ]
+
+        for (command, unicode) in symbols {
+            var error: NSError? = nil
+            let str = "\\\(command)"
+            let list = MTMathListBuilder.build(fromString: str, error: &error)
+
+            let unwrappedList = try XCTUnwrap(list, "Should parse \\\(command)")
+            XCTAssertNil(error, "Should not error on \\\(command)")
+            XCTAssertEqual(unwrappedList.atoms.count, 1)
+            XCTAssertEqual(unwrappedList.atoms[0].type, .relation)
+            XCTAssertEqual(unwrappedList.atoms[0].nucleus, unicode, "\\\(command) should have unicode \(unicode)")
+        }
+    }
+
+    func testNegatedSquareSubsetRelations() throws {
+        let symbols: [(command: String, unicode: String)] = [
+            ("nsqsubseteq", "\u{22E2}"),  // ⋢
+            ("nsqsupseteq", "\u{22E3}"),  // ⋣
+        ]
+
+        for (command, unicode) in symbols {
+            var error: NSError? = nil
+            let str = "\\\(command)"
+            let list = MTMathListBuilder.build(fromString: str, error: &error)
+
+            let unwrappedList = try XCTUnwrap(list, "Should parse \\\(command)")
+            XCTAssertNil(error, "Should not error on \\\(command)")
+            XCTAssertEqual(unwrappedList.atoms.count, 1)
+            XCTAssertEqual(unwrappedList.atoms[0].type, .relation)
+            XCTAssertEqual(unwrappedList.atoms[0].nucleus, unicode, "\\\(command) should have unicode \(unicode)")
+        }
     }
 
 }


### PR DESCRIPTION
## Summary

This PR adds Priority 1 LaTeX symbols and 48 negated relation symbols from amssymb.

### Priority 1 Symbol Additions

**Bug Fix:**
- **varsigma**: Corrected Unicode from U+03C1 (rho) to U+03C2 (final sigma)

**New Symbol Mappings (18 symbols):**

| Category | Symbols |
|----------|---------|
| Greek variants | varkappa (U+03F0) |
| Arrows | longmapsto (U+27FC), hookrightarrow (U+21AA), hookleftarrow (U+21A9) |
| Slanted inequalities | leqslant (U+2A7D), geqslant (U+2A7E) |
| Precedence relations | preceq (U+2AAF), succeq (U+2AB0) |
| Turnstile relations | vdash (U+22A2), dashv (U+22A3), bowtie (U+22C8) |
| Binary operators | diamond (U+22C4) |
| Hebrew letters | beth (U+2136), gimel (U+2137), daleth (U+2138) |
| Miscellaneous | varnothing (U+2205), Box (U+25A1), measuredangle (U+2221) |

Note: digamma (U+03DD) and Digamma (U+03DC) were initially added but removed as they are not supported by Latin Modern Math font.

### Negated Relations (48 symbols)

| Category | Symbols |
|----------|---------|
| Inequality negations (14) | `\nless`, `\ngtr`, `\nleq`, `\ngeq`, `\nleqslant`, `\ngeqslant`, `\lneq`, `\gneq`, `\lneqq`, `\gneqq`, `\lnsim`, `\gnsim`, `\lnapprox`, `\gnapprox` |
| Ordering negations (10) | `\nprec`, `\nsucc`, `\npreceq`, `\nsucceq`, `\precneqq`, `\succneqq`, `\precnsim`, `\succnsim`, `\precnapprox`, `\succnapprox` |
| Similarity/Congruence (6) | `\nsim`, `\ncong`, `\nmid`, `\nshortmid`, `\nparallel`, `\nshortparallel` |
| Set relations (12) | `\nsubseteq`, `\nsupseteq`, `\subsetneq`, `\supsetneq`, `\subsetneqq`, `\supsetneqq`, `\varsubsetneq`, `\varsupsetneq`, `\varsubsetneqq`, `\varsupsetneqq`, `\notni`, `\nni` |
| Triangle (4) | `\ntriangleleft`, `\ntriangleright`, `\ntrianglelefteq`, `\ntrianglerighteq` |
| Turnstile (4) | `\nvdash`, `\nvDash`, `\nVdash`, `\nVDash` |
| Square subset (2) | `\nsqsubseteq`, `\nsqsupseteq` |

## Test Plan

- [x] Run existing tests to verify no regressions
- [x] Unit tests for all new symbols verify correct parsing and Unicode values
- [x] Visual render tests generate PNG images for verification:
  - Priority 1 symbols: 10 test images
  - Negated relations: 18 test images
- [x] Verify all test images render correctly

## Notes

- All changes are additive - no breaking changes
- Some Priority 1 symbols may overlap with PR #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)
