### PR TITLE
Don't trap on invalid inter-element spacing (e.g. Relation followed by Binary Operator)

### DIFF
--- a/Sources/SwiftMath/MathRender/MTTypesetter.swift
+++ b/Sources/SwiftMath/MathRender/MTTypesetter.swift
@@ -807,8 +807,14 @@ class MTTypesetter {
         let spaceArray = getInterElementSpaces()[Int(leftIndex)]
         let spaceTypeObj = spaceArray[Int(rightIndex)]
         let spaceType = spaceTypeObj
-        assert(spaceType != .invalid, "Invalid space between \(left) and \(right)")
-        
+        // An "invalid" adjacency (e.g. a Relation immediately followed by a
+        // Binary Operator, as in `x = -1`) is a valid math list that simply has
+        // no defined inter-element spacing. Render it with zero spacing instead
+        // of trapping: the previous `assert(spaceType != .invalid, ...)` crashed
+        // debug builds on perfectly valid equations, while release builds (where
+        // assertions are compiled out) already fell through to `return 0`.
+        if spaceType == .invalid { return 0 }
+
         let spaceMultipler = self.getSpacingInMu(spaceType)
         if spaceMultipler > 0 {
             // 1 em = size of font in pt. space multipler is in multiples mu or 1/18 em


### PR DESCRIPTION
## Problem
`MTTypesetter.getInterElementSpace(_:_:)` asserts that the inter-element spacing type for an adjacent atom pair is never `.invalid`:

```swift
assert(spaceType != .invalid, "Invalid space between \(left) and \(right)")
```

But some perfectly valid math lists produce an `.invalid` adjacency — most commonly a **Relation immediately followed by a Binary Operator**, e.g. `x = -1`, `a = -b + c`, `y < -3`. In a DEBUG build this `assert` traps and **crashes the app on valid equations**. In release the assertion is compiled out and the function already falls through to `return 0`, so release behavior is "zero spacing" — only debug crashes.

## Fix
Handle `.invalid` explicitly by returning `0` spacing (matching the existing release-build fall-through), instead of asserting:

```swift
if spaceType == .invalid { return 0 }
```

This makes debug and release consistent and stops valid equations from crashing debug builds. No change to spacing for any non-`.invalid` adjacency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)