### PR TITLE
Nthroot display fixes

### DIFF
--- a/Sources/SwiftMath/MathRender/MTMathListDisplay.swift
+++ b/Sources/SwiftMath/MathRender/MTMathListDisplay.swift
@@ -441,10 +441,11 @@ class MTRadicalDisplay : MTDisplay {
         set {
             super.position = newValue
             self.updateRadicandPosition()
+            self.updateDegreePosition()
         }
         get { super.position }
     }
-    
+
     override var textColor: MTColor? {
         set {
             super.textColor = newValue
@@ -453,9 +454,15 @@ class MTRadicalDisplay : MTDisplay {
         }
         get { super.textColor }
     }
-    
+
     private var _radicalGlyph:MTDisplay?
     private var _radicalShift:CGFloat=0
+    // Offset of the degree relative to the radical's origin. Cached so the degree can be
+    // repositioned whenever the radical itself is moved (e.g. by inter-element spacing or
+    // line-wrap adjustments). `raise` depends only on ascent/descent, which are fixed before
+    // the degree is set, so caching it is safe.
+    private var _degreeKernBefore:CGFloat=0
+    private var _degreeRaise:CGFloat=0
     
     var topKern:CGFloat=0
     var lineThickness:CGFloat=0
@@ -489,12 +496,21 @@ class MTRadicalDisplay : MTDisplay {
             _radicalShift = 0;
         }
         
-        // Note: position of degree is relative to parent.
-        self.degree!.position = CGPointMake(self.position.x + kernBefore, self.position.y + raise);
+        // Cache the degree's offset relative to the radical origin so it tracks the radical
+        // if the radical is later repositioned, then place it.
+        _degreeKernBefore = kernBefore;
+        _degreeRaise = raise;
+        self.updateDegreePosition()
         // Update the width by the _radicalShift
         self.width = _radicalShift + _radicalGlyph!.width + self.radicand!.width;
         // update the position of the radicand
         self.updateRadicandPosition()
+    }
+
+    func updateDegreePosition() {
+        guard let degree = self.degree else { return }
+        // Note: position of degree is relative to parent.
+        degree.position = CGPointMake(self.position.x + _degreeKernBefore, self.position.y + _degreeRaise);
     }
 
     func updateRadicandPosition() {

--- a/Sources/SwiftMath/MathRender/MTTypesetter.swift
+++ b/Sources/SwiftMath/MathRender/MTTypesetter.swift
@@ -1657,12 +1657,15 @@ class MTTypesetter {
                 let minYCompensation = max(0, glyphMinY)
                 height = accentee.ascent + arrowSpacing - minYCompensation
             } else {
-                // Non-stretchy arrows (\vec): use tight spacing like regular accents
-                // This gives a more compact appearance suitable for single-character vectors
-                delta = min(accentee.ascent, mathTable.accentBaseHeight)
-                // Use same formula as regular accents (no minYCompensation adjustment)
-                // This places the arrow properly above the character
-                height = accentee.ascent - delta
+                // Non-stretchy arrows (\vec): place the arrow just above the accentee
+                // (centered, no horizontal scaling). A positive gap above the ascent
+                // prevents the arrow from overlapping the base character — the previous
+                // `ascent - delta` formula collapsed onto the letter for x-height glyphs.
+                delta = 0
+                let arrowSpacing = mathTable.upperLimitGapMin
+                // Compensate for internal glyph whitespace (minY > 0)
+                let minYCompensation = max(0, glyphMinY)
+                height = accentee.ascent + arrowSpacing - minYCompensation
             }
 
             // For stretchy arrow accents (\overrightarrow): if the largest glyph variant is still smaller than content width,

--- a/Sources/SwiftMath/MathRender/MTTypesetter.swift
+++ b/Sources/SwiftMath/MathRender/MTTypesetter.swift
@@ -738,7 +738,12 @@ class MTTypesetter {
     }
     
     func numeratorGapMin() -> CGFloat {
-        if style == .display {
+        // TeX/KaTeX use the (small) text-style gap min for inline fractions, which
+        // makes the numerator hug the bar. We intentionally use the larger
+        // display-style clearance for text style too, so inline fractions get the
+        // same breathing room as display fractions. The smaller script styles keep
+        // their compact gap so deeply nested fractions are not over-spaced.
+        if style == .display || style == .text {
             return styleFont.mathTable!.fractionNumeratorDisplayStyleGapMin;
         } else {
             return styleFont.mathTable!.fractionNumeratorGapMin;
@@ -762,7 +767,9 @@ class MTTypesetter {
     }
     
     func denominatorGapMin() -> CGFloat {
-        if style == .display {
+        // See numeratorGapMin(): inline (text) fractions use the larger
+        // display-style clearance so the denominator does not hug the bar.
+        if style == .display || style == .text {
             return styleFont.mathTable!.fractionDenominatorDisplayStyleGapMin;
         } else {
             return styleFont.mathTable!.fractionDenominatorGapMin;

--- a/Sources/SwiftMath/MathRender/MTTypesetter.swift
+++ b/Sources/SwiftMath/MathRender/MTTypesetter.swift
@@ -63,8 +63,9 @@ func getInterElementSpaceArrayIndexForType(_ type:MTMathAtomType, row:Bool) -> I
             return 5;
         case .punctuation:
             return 6;
-        case .fraction,  // Fraction and inner are treated the same.
-             .inner:
+        case .fraction,  // Fraction, inner and table are treated the same.
+             .inner,
+             .table:
             return 7;
         case .radical:
             if row {
@@ -83,7 +84,7 @@ func getInterElementSpaceArrayIndexForType(_ type:MTMathAtomType, row:Bool) -> I
         case .accent, .underline, .overline:
             return 0
         // Special types that don't typically participate in spacing are treated as ordinary
-        case .boundary, .space, .style, .table:
+        case .boundary, .space, .style:
             return 0
     }
 }

--- a/Tests/SwiftMathTests/FractionBarOverlapTests.swift
+++ b/Tests/SwiftMathTests/FractionBarOverlapTests.swift
@@ -1,0 +1,160 @@
+//
+//  FractionBarOverlapTests.swift
+//  SwiftMathTests
+//
+//  Verifies that the numerator and denominator of a fraction do not overlap
+//  the fraction bar, and that there is adequate clearance (the reported issue
+//  is that boxes appear to touch / overlap the bar).
+//
+
+import XCTest
+@testable import SwiftMath
+
+final class FractionBarOverlapTests: XCTestCase {
+
+    var font: MTFont!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        self.font = MTFontManager.fontManager.defaultFont
+    }
+
+    override func tearDownWithError() throws {
+        self.font = nil
+        try super.tearDownWithError()
+    }
+
+    /// Recursively collects every MTFractionDisplay in a display tree, descending
+    /// into list displays as well as into the numerator/denominator of fractions.
+    private func collectFractions(_ display: MTDisplay) -> [MTFractionDisplay] {
+        var result = [MTFractionDisplay]()
+        if let frac = display as? MTFractionDisplay {
+            result.append(frac)
+            if let num = frac.numerator { result += collectFractions(num) }
+            if let denom = frac.denominator { result += collectFractions(denom) }
+        } else if let list = display as? MTMathListDisplay {
+            for sub in list.subDisplays {
+                result += collectFractions(sub)
+            }
+        }
+        return result
+    }
+
+    /// For a single fraction, returns the clearance (in points) between the bottom
+    /// of the numerator and the top edge of the bar, and between the top of the
+    /// denominator and the bottom edge of the bar. Negative means overlap.
+    private func gaps(for frac: MTFractionDisplay) -> (numeratorGap: CGFloat, denominatorGap: CGFloat) {
+        let halfThickness = frac.lineThickness / 2
+
+        // Bar edges in absolute (line) coordinates.
+        let barTop = frac.position.y + frac.linePosition + halfThickness
+        let barBottom = frac.position.y + frac.linePosition - halfThickness
+
+        // Numerator sits above the bar: its lowest drawn edge is position.y - descent.
+        let numeratorBottom = frac.numerator!.position.y - frac.numerator!.descent
+        // Denominator sits below the bar: its highest drawn edge is position.y + ascent.
+        let denominatorTop = frac.denominator!.position.y + frac.denominator!.ascent
+
+        let numeratorGap = numeratorBottom - barTop
+        let denominatorGap = barBottom - denominatorTop
+        return (numeratorGap, denominatorGap)
+    }
+
+    private func assertNoBarOverlap(latex: String, style: MTLineStyle = .display, file: StaticString = #file, line: UInt = #line) {
+        guard let mathList = MTMathListBuilder.build(fromString: latex) else {
+            XCTFail("Failed to parse: \(latex)", file: file, line: line)
+            return
+        }
+        guard let display = MTTypesetter.createLineForMathList(mathList, font: self.font, style: style) else {
+            XCTFail("Failed to typeset: \(latex)", file: file, line: line)
+            return
+        }
+
+        let fractions = collectFractions(display)
+        XCTAssertFalse(fractions.isEmpty, "Expected at least one fraction in: \(latex)", file: file, line: line)
+
+        print("\n=== \(latex) (\(fractions.count) fraction(s)) ===")
+        for (i, frac) in fractions.enumerated() {
+            let g = gaps(for: frac)
+            print(String(format: "  frac[%d]: barThickness=%.3f linePos=%.3f numeratorUp=%.3f denominatorDown=%.3f | numGap=%.3f denomGap=%.3f",
+                         i, frac.lineThickness, frac.linePosition, frac.numeratorUp, frac.denominatorDown, g.numeratorGap, g.denominatorGap))
+
+            // Only fractions that actually draw a rule are relevant here.
+            guard frac.lineThickness > 0 else { continue }
+
+            // The numerator/denominator boxes must not overlap the bar. A tiny
+            // negative tolerance accounts for floating point rounding only.
+            XCTAssertGreaterThanOrEqual(g.numeratorGap, -0.001,
+                "Numerator overlaps the fraction bar (gap=\(g.numeratorGap)) in: \(latex)", file: file, line: line)
+            XCTAssertGreaterThanOrEqual(g.denominatorGap, -0.001,
+                "Denominator overlaps the fraction bar (gap=\(g.denominatorGap)) in: \(latex)", file: file, line: line)
+        }
+    }
+
+    // MARK: - The reported equations
+
+    func testSimpleFraction() {
+        assertNoBarOverlap(latex: "\\(\\frac{3}{4}\\)")
+    }
+
+    func testNestedFraction() {
+        assertNoBarOverlap(latex: "\\(\\frac{1 + \\frac{1}{x}}{2 - \\frac{1}{y}}\\)")
+    }
+
+    func testDerivativeFraction() {
+        assertNoBarOverlap(latex: "\\(\\frac{d}{dx}f(x)\\)")
+    }
+
+    func testPartialDerivativeFraction() {
+        assertNoBarOverlap(latex: "\\(\\frac{\\partial^2 f}{\\partial x \\partial y}\\)")
+    }
+
+    // MARK: - Aggregate, also exercising text style (inline) sizing
+
+    /// `\(...\)` inline delimiters make the builder prepend a `\textstyle` atom,
+    /// forcing text-style rendering. Plain TeX/KaTeX then use a minimal text-style
+    /// gap (1× rule thickness ≈ 0.8pt at 20pt), which makes inline fractions hug
+    /// the bar. SwiftMath intentionally raises the inline clearance to the
+    /// display-style gap min (3× rule thickness ≈ 2.4pt) so inline fractions get
+    /// the same breathing room as display fractions. This test guards that the
+    /// inline denominator clearance is no longer the tight 0.8pt value.
+    func testInlineUsesDisplayClearance() {
+        // Bare LaTeX (no \(...\)) typeset in display style.
+        let displayList = MTMathListBuilder.build(fromString: "\\frac{3}{4}")!
+        let displayFrac = collectFractions(
+            MTTypesetter.createLineForMathList(displayList, font: font, style: .display)!).first!
+        let displayGaps = gaps(for: displayFrac)
+
+        // Inline \(...\) → builder forces \textstyle.
+        let inlineList = MTMathListBuilder.build(fromString: "\\(\\frac{3}{4}\\)")!
+        let inlineFrac = collectFractions(
+            MTTypesetter.createLineForMathList(inlineList, font: font, style: .display)!).first!
+        let inlineGaps = gaps(for: inlineFrac)
+
+        print(String(format: "\n=== inline vs display 3/4 ===\n  display: numGap=%.3f denomGap=%.3f\n  inline : numGap=%.3f denomGap=%.3f",
+                     displayGaps.numeratorGap, displayGaps.denominatorGap,
+                     inlineGaps.numeratorGap, inlineGaps.denominatorGap))
+
+        // Inline clearance is now at least the display-style gap min (≈2.4pt),
+        // not the old tight 0.8pt text-style value.
+        XCTAssertGreaterThanOrEqual(inlineGaps.denominatorGap, 2.39,
+                       "Inline denominator gap should use the display-style clearance")
+        XCTAssertGreaterThanOrEqual(inlineGaps.numeratorGap, 2.39,
+                       "Inline numerator gap should use the display-style clearance")
+        XCTAssertGreaterThanOrEqual(displayGaps.denominatorGap, 2.39,
+                       "Display-style denominator gap should be at least the display gap min")
+    }
+
+    func testAllReportedEquationsDisplayAndText() {
+        let equations = [
+            "\\(\\frac{3}{4}\\)",
+            "\\(\\frac{1 + \\frac{1}{x}}{2 - \\frac{1}{y}}\\)",
+            "\\(\\frac{d}{dx}f(x)\\)",
+            "\\(\\frac{\\partial^2 f}{\\partial x \\partial y}\\)",
+        ]
+        for eq in equations {
+            assertNoBarOverlap(latex: eq, style: .display)
+            assertNoBarOverlap(latex: eq, style: .text)
+        }
+    }
+}

--- a/Tests/SwiftMathTests/MTMathUILabelLineWrappingTests.swift
+++ b/Tests/SwiftMathTests/MTMathUILabelLineWrappingTests.swift
@@ -2049,4 +2049,42 @@ class MTMathUILabelLineWrappingTests: XCTestCase {
                 "Script glyphs were duplicated during line-wrap layout: '\(fragment)'")
         }
     }
+
+    func testTextAfterScriptedAtomFillsRemainderOfLine() {
+        // Regression: after a scripted atom (x^{1/16}) flushes, the pen is mid-line. The following
+        // \text{...} run must continue on the SAME line and fill the remaining width — it must not be
+        // pushed wholesale to the next line (which wasted ~half the line).
+        let label = MTMathUILabel()
+        label.latex = "\\(\\text{Note that }x^{1/16}\\text{ is not real for negative }x" +
+                      "\\text{, so the integral over any interval containing negative values is not defined in the real numbers.}\\)"
+        label.font = MTFontManager.fontManager.defaultFont
+        let maxWidth: CGFloat = 300
+        label.preferredMaxLayoutWidth = maxWidth
+        _ = label.intrinsicContentSize
+        label.frame = CGRect(x: 0, y: 0, width: maxWidth, height: 200)
+        #if os(macOS)
+        label.layout()
+        #else
+        label.layoutSubviews()
+        #endif
+        XCTAssertNil(label.error, "Should render without error")
+
+        guard let subDisplays = label.displayList?.subDisplays, !subDisplays.isEmpty else {
+            XCTFail("Display list should be created")
+            return
+        }
+
+        // Identify the first (top) text line by the baseline of the text displays (the superscript
+        // of x^{1/16} sits above the baseline, so use MTCTLineDisplay positions, not all displays).
+        let textLines = subDisplays.compactMap { $0 as? MTCTLineDisplay }.filter { $0.width > 0 }
+        let firstLineY = textLines.map { $0.position.y }.max()!
+        // After the script, text must continue on the first line — its right edge must fill well past
+        // the base nucleus rather than wrapping the whole run to the next line.
+        let firstLineTextRight = textLines
+            .filter { abs($0.position.y - firstLineY) < 1.0 }
+            .map { $0.position.x + $0.width }
+            .max() ?? 0
+        XCTAssertGreaterThan(firstLineTextRight, maxWidth * 0.6,
+            "First line ends at \(firstLineTextRight) — text was not packed onto the line after the scripted atom (premature break)")
+    }
 }

--- a/Tests/SwiftMathTests/MTMathUILabelLineWrappingTests.swift
+++ b/Tests/SwiftMathTests/MTMathUILabelLineWrappingTests.swift
@@ -1901,4 +1901,152 @@ class MTMathUILabelLineWrappingTests: XCTestCase {
             }
         }
     }
+
+    // MARK: - Mixed text + math overflow regression
+
+    /// Lay out `latex` constrained to `maxWidth` and assert that no top-level display spills
+    /// past the right edge. A display whose right edge exceeds the constraint is rendered
+    /// off-screen and is effectively invisible — the symptom reported for `\sum`/`\int`/`x^{p}`
+    /// following text that nearly fills a line.
+    private func assertNoRightEdgeOverflow(_ latex: String, maxWidth: CGFloat,
+                                           file: StaticString = #file, line: UInt = #line) {
+        let label = MTMathUILabel()
+        label.latex = latex
+        label.font = MTFontManager.fontManager.defaultFont
+        XCTAssertNil(label.error, "Should parse without error: \(String(describing: label.error))", file: file, line: line)
+
+        label.preferredMaxLayoutWidth = maxWidth
+        let size = label.intrinsicContentSize
+        label.frame = CGRect(origin: .zero, size: size)
+        #if os(macOS)
+        label.layout()
+        #else
+        label.layoutSubviews()
+        #endif
+
+        guard let displayList = label.displayList else {
+            XCTFail("Display list should be created", file: file, line: line)
+            return
+        }
+        XCTAssertNil(label.error, "Should render without error", file: file, line: line)
+
+        // Allow a small tolerance for sub-pixel italic correction / spacing.
+        let tolerance: CGFloat = 2.0
+        for display in displayList.subDisplays {
+            if display.width <= 0 { continue }  // zero-width displays render nothing
+            let rightEdge = display.position.x + display.width
+            XCTAssertLessThanOrEqual(rightEdge, maxWidth + tolerance,
+                "A display's right edge (\(rightEdge)) overflows the width constraint (\(maxWidth)) — content is rendered off-screen",
+                file: file, line: line)
+        }
+    }
+
+    func testMixedTextWithSumIntegralRadicalDoesNotOverflow() {
+        // Reported entry 1 (in the single-\(...\) form the app feeds to SwiftMath): a long text
+        // run followed by \sum / \int / \sqrt. Before the fix the operators were placed past the
+        // right edge and never wrapped, so the whole math tail disappeared.
+        let latex = "\\(\\text{What would you like to do with the expression involving the sum and the integral }" +
+                    "\\sum_{-1/x}^{+1/x} \\int_{-\\infty}^{+\\infty} \\sqrt[16]{x}\\,dx\\text{?}\\)"
+        assertNoRightEdgeOverflow(latex, maxWidth: 250)
+    }
+
+    func testMixedTextWithScriptedAtomsDoesNotOverflow() {
+        // Reported entry 2: \text{} blocks interleaved with x^{p} and \int. Before the fix the
+        // scripted atoms broke between base and script (or were placed off-screen).
+        let latex = "\\(\\text{Check convergence on }[0,+\\infty)\\text{: for }x^{p}\\text{ with }p>-1\\text{, }" +
+                    "\\int_{0}^{1} x^{p} dx\\text{ converges, but }\\int_{1}^{+\\infty} x^{p} dx\\text{ diverges. Here, }" +
+                    "p=\\frac{1}{16}>-1\\text{, so the integral from 1 to }+\\infty\\text{ diverges.}\\)"
+        assertNoRightEdgeOverflow(latex, maxWidth: 250)
+    }
+
+    /// Lay out `latex` constrained to `maxWidth` and assert that no large operator (e.g. \sum with
+    /// stacked limits) sitting on a continuation line vertically intrudes into a display that sits
+    /// on a line above it and horizontally overlaps it. A tall operator must push its line down far
+    /// enough to clear the line above.
+    private func assertLargeOperatorsDoNotOverlapLinesAbove(_ latex: String, maxWidth: CGFloat,
+                                                            file: StaticString = #file, line: UInt = #line) {
+        let label = MTMathUILabel()
+        label.latex = latex
+        label.font = MTFontManager.fontManager.defaultFont
+        XCTAssertNil(label.error, "Should parse without error: \(String(describing: label.error))", file: file, line: line)
+
+        label.preferredMaxLayoutWidth = maxWidth
+        let size = label.intrinsicContentSize
+        label.frame = CGRect(origin: .zero, size: size)
+        #if os(macOS)
+        label.layout()
+        #else
+        label.layoutSubviews()
+        #endif
+
+        guard let displayList = label.displayList else {
+            XCTFail("Display list should be created", file: file, line: line)
+            return
+        }
+
+        // In the Y-up coordinate system: top = pos + ascent (higher Y), bottom = pos - descent.
+        // A display on a higher line has a larger baseline y. The operator (lower line) must sit
+        // entirely below any display above it that shares horizontal space.
+        let lineGap: CGFloat = 15.0
+        let ops = displayList.subDisplays.filter { $0 is MTLargeOpLimitsDisplay }
+        for op in ops {
+            let opTop = op.position.y + op.ascent
+            let opRange = op.position.x ... (op.position.x + op.width)
+            for other in displayList.subDisplays where other !== op {
+                // Only consider displays that are on a line above the operator.
+                guard other.position.y > op.position.y + lineGap else { continue }
+                let oLeft = other.position.x, oRight = other.position.x + other.width
+                let xOverlap = min(opRange.upperBound, oRight) - max(opRange.lowerBound, oLeft)
+                guard xOverlap > 0 else { continue }
+                let otherBottom = other.position.y - other.descent
+                XCTAssertLessThanOrEqual(opTop, otherBottom + 0.5,
+                    "Large operator (top \(opTop)) overlaps a display above it (bottom \(otherBottom))",
+                    file: file, line: line)
+            }
+        }
+    }
+
+    func testLargeOperatorWithLimitsOnSecondLineNoOverlap() {
+        // Reported issue: the \sum lands on the second line and its stacked superscript (+1/x)
+        // overlapped the first line of text. The operator's line must drop to clear the line above.
+        let latex = "\\(\\text{What would you like to do with the expression }" +
+                    "\\sum_{-1/x}^{+1/x} \\int_{-\\infty}^{+\\infty} \\sqrt[16]{x}\\,dx\\text{?}\\)"
+        assertLargeOperatorsDoNotOverlapLinesAbove(latex, maxWidth: 250)
+        assertNoRightEdgeOverflow(latex, maxWidth: 250)
+    }
+
+    func testLargeOperatorScriptsAreNotDuplicatedWhenWrapping() {
+        // Regression: the width-estimation used for line-break decisions must not mutate the live
+        // script lists. createLineForMathList runs preprocessMathList, which fuses adjacent ordinary
+        // atoms in place; measuring the real lists made the subsequent render fuse a second time,
+        // duplicating glyphs (the \sum / \int limits showed "+∞∞" / "−∞∞").
+        let label = MTMathUILabel()
+        label.latex = "\\(\\sum_{-1/x}^{+1/x}\\int_{-\\infty}^{+\\infty}\\sqrt[16]{x}\\,dx\\)"
+        label.font = MTFontManager.fontManager.defaultFont
+        label.preferredMaxLayoutWidth = 250
+        _ = label.intrinsicContentSize
+        label.frame = CGRect(x: 0, y: 0, width: 250, height: 200)
+        #if os(macOS)
+        label.layout()
+        #else
+        label.layoutSubviews()
+        #endif
+        XCTAssertNil(label.error, "Should render without error")
+
+        // Collect every rendered text fragment.
+        var fragments: [String] = []
+        func walk(_ d: MTDisplay) {
+            if let l = d as? MTCTLineDisplay, let s = l.attributedString?.string, !s.isEmpty {
+                fragments.append(s)
+            }
+            if let ml = d as? MTMathListDisplay { ml.subDisplays.forEach(walk) }
+        }
+        (label.displayList?.subDisplays ?? []).forEach(walk)
+
+        // No fragment should contain a repeated infinity glyph (the duplication signature).
+        for fragment in fragments {
+            XCTAssertFalse(fragment.contains("∞∞"),
+                "Script glyphs were duplicated during line-wrap layout: '\(fragment)'")
+        }
+    }
 }

--- a/Tests/SwiftMathTests/MTTypesetterTests.swift
+++ b/Tests/SwiftMathTests/MTTypesetterTests.swift
@@ -430,6 +430,111 @@ final class MTTypesetterTests: XCTestCase {
         XCTAssertLessThan(display.width, 35, "Width should be reasonable")
     }
 
+    // MARK: - nth-root degree positioning regression tests
+
+    /// Recursively collects the absolute frames of every radical degree (paired with its
+    /// parent radical's absolute frame) and every superscript line in a display tree.
+    /// `origin` is the absolute coordinate of the frame in which `display.position` is expressed.
+    private func collectDegreesAndSuperscripts(_ display: MTDisplay,
+                                               origin: CGPoint,
+                                               degrees: inout [(radical: CGRect, degree: CGRect)],
+                                               superscripts: inout [CGRect]) {
+        func absFrame(_ d: MTDisplay) -> CGRect {
+            CGRect(x: origin.x + d.position.x,
+                   y: origin.y + d.position.y - d.descent,
+                   width: d.width,
+                   height: d.ascent + d.descent)
+        }
+        switch display {
+        case let radical as MTRadicalDisplay:
+            // radicand/degree positions share the radical's own coordinate frame (origin),
+            // so recurse them with the same origin.
+            if let degree = radical.degree {
+                degrees.append((radical: absFrame(radical), degree: absFrame(degree)))
+                collectDegreesAndSuperscripts(degree, origin: origin, degrees: &degrees, superscripts: &superscripts)
+            }
+            if let radicand = radical.radicand {
+                collectDegreesAndSuperscripts(radicand, origin: origin, degrees: &degrees, superscripts: &superscripts)
+            }
+        case let fraction as MTFractionDisplay:
+            if let n = fraction.numerator { collectDegreesAndSuperscripts(n, origin: origin, degrees: &degrees, superscripts: &superscripts) }
+            if let d = fraction.denominator { collectDegreesAndSuperscripts(d, origin: origin, degrees: &degrees, superscripts: &superscripts) }
+        case let op as MTLargeOpLimitsDisplay:
+            if let u = op.upperLimit { collectDegreesAndSuperscripts(u, origin: origin, degrees: &degrees, superscripts: &superscripts) }
+            if let l = op.lowerLimit { collectDegreesAndSuperscripts(l, origin: origin, degrees: &degrees, superscripts: &superscripts) }
+        case let line as MTLineDisplay:
+            if let inner = line.inner { collectDegreesAndSuperscripts(inner, origin: origin, degrees: &degrees, superscripts: &superscripts) }
+        case let accent as MTAccentDisplay:
+            if let accentee = accent.accentee { collectDegreesAndSuperscripts(accentee, origin: origin, degrees: &degrees, superscripts: &superscripts) }
+        case let list as MTMathListDisplay:
+            if list.type == .superscript {
+                superscripts.append(absFrame(list))
+            }
+            // Children of a math list are drawn after translating by the list's own position.
+            let childOrigin = CGPoint(x: origin.x + list.position.x, y: origin.y + list.position.y)
+            for sub in list.subDisplays {
+                collectDegreesAndSuperscripts(sub, origin: childOrigin, degrees: &degrees, superscripts: &superscripts)
+            }
+        default:
+            break
+        }
+    }
+
+    /// Focused regression: when a radical is preceded by inter-element spacing (here a binary
+    /// operator), its degree must not slide to the left of the radical sign. Before the fix the
+    /// degree kept the position computed before the inter-element space was added, ending up
+    /// shifted left and overlapping preceding content.
+    func testRadicalDegreeNotShiftedLeft() throws {
+        let mathList = MTMathListBuilder.build(fromString: "1+\\sqrt[3]{x}")
+        XCTAssertNotNil(mathList)
+        let display = MTTypesetter.createLineForMathList(mathList, font: self.font, style: .display)!
+
+        let radical = display.subDisplays.compactMap { $0 as? MTRadicalDisplay }.first
+        XCTAssertNotNil(radical, "Expected a radical display")
+        let degree = radical!.degree
+        XCTAssertNotNil(degree, "Expected the radical to have a degree")
+
+        // The degree must sit at or to the right of the radical's origin, never to its left.
+        XCTAssertGreaterThanOrEqual(degree!.position.x, radical!.position.x,
+                                    "Degree is shifted left of its radical (position.x = \(degree!.position.x) < \(radical!.position.x))")
+        // The degree must also stay within the radical's overall bounds.
+        XCTAssertLessThanOrEqual(degree!.position.x + degree!.width,
+                                 radical!.position.x + radical!.width,
+                                 "Degree extends past the right edge of the radical")
+    }
+
+    /// For each of the originally reported inputs, the degree must (a) not be shifted left of its
+    /// own radical and (b) not overlap any superscript box elsewhere in the expression.
+    func testRadicalDegreeDoesNotOverlapSuperscripts() throws {
+        let inputs = [
+            "y^3=\\sqrt[3]{x}",
+            "\\frac{1}{\\sqrt[8]{x}}",
+            "\\sum_{\\frac{+1}{x}}^{\\frac{-1}{x}}\\int_{-\\infty}^{\\infty}\\sqrt[16]{x}dx",
+        ]
+        for input in inputs {
+            let mathList = MTMathListBuilder.build(fromString: input)
+            XCTAssertNotNil(mathList, "Failed to parse \(input)")
+            let display = MTTypesetter.createLineForMathList(mathList, font: self.font, style: .display)!
+
+            var degrees = [(radical: CGRect, degree: CGRect)]()
+            var superscripts = [CGRect]()
+            collectDegreesAndSuperscripts(display, origin: .zero, degrees: &degrees, superscripts: &superscripts)
+
+            XCTAssertFalse(degrees.isEmpty, "Expected at least one radical degree for \(input)")
+
+            for entry in degrees {
+                // (a) The degree's left edge must not be left of its radical's left edge.
+                XCTAssertGreaterThanOrEqual(entry.degree.minX, entry.radical.minX - 0.01,
+                                            "Degree shifted left of its radical for \(input): degree=\(entry.degree) radical=\(entry.radical)")
+                // (b) The degree must not overlap any superscript box.
+                for sup in superscripts {
+                    XCTAssertFalse(entry.degree.intersects(sup),
+                                   "Degree box \(entry.degree) overlaps superscript box \(sup) for \(input)")
+                }
+            }
+        }
+    }
+
     func testFraction() throws {
         let mathList = MTMathList()
         let frac = MTFraction(hasRule: true)

--- a/Tests/SwiftMathTests/MTTypesetterTests.swift
+++ b/Tests/SwiftMathTests/MTTypesetterTests.swift
@@ -2372,6 +2372,46 @@ final class MTTypesetterTests: XCTestCase {
         XCTAssertNotNil(display, "Matrices render (force breaks)")
     }
 
+    /// Regression for a crash in createDisplayAtoms: a delimited matrix (e.g. pmatrix) wraps an
+    /// MTMathTable in an MTInner. makeLeftRight typesets the inner content twice (once to size the
+    /// delimiters, once to lay it out). The typesetter used to mutate the table atom's `type` to
+    /// `.inner`, so on the second pass the same atom was routed into the `.inner` case and
+    /// `atom as! MTInner` crashed with "Could not cast MTMathTable to MTInner".
+    func testDelimitedMatrixDoesNotCrash() throws {
+        let latex = "\\(\\begin{pmatrix} x \\\\ y \\\\ z \\end{pmatrix}\\)"
+        let mathList = MTMathListBuilder.build(fromString: latex)
+        XCTAssertNotNil(mathList, "Failed to parse LaTeX")
+
+        // A single typesetting pass already triggers the double layout inside makeLeftRight.
+        let display = MTTypesetter.createLineForMathList(mathList, font: self.font, style: .display)
+        XCTAssertNotNil(display)
+        XCTAssertGreaterThan(display!.width, 0)
+
+        // pmatrix produces an MTInner wrapping the table; the table's type must be preserved.
+        let inner = mathList!.atoms.compactMap { $0 as? MTInner }.first
+        XCTAssertNotNil(inner, "Expected pmatrix to produce an MTInner")
+        let table = inner!.innerList!.atoms.compactMap { $0 as? MTMathTable }.first
+        XCTAssertNotNil(table, "Expected the inner list to contain an MTMathTable")
+        XCTAssertEqual(table!.type, .table, "Typesetting must not mutate the table atom's type")
+    }
+
+    /// Mirrors MTMathUILabel.intrinsicContentSize followed by drawing: the same MTMathList is
+    /// typeset more than once. The atom tree must be reusable across passes without corruption.
+    func testRepeatedTypesettingOfMatrixIsStable() throws {
+        let latex = "\\(\\begin{pmatrix} x \\\\ y \\\\ z \\end{pmatrix}\\)"
+        let mathList = MTMathListBuilder.build(fromString: latex)
+        XCTAssertNotNil(mathList, "Failed to parse LaTeX")
+
+        let first = MTTypesetter.createLineForMathList(mathList, font: self.font, style: .display)
+        XCTAssertNotNil(first)
+        // Second pass on the same (shared) atom tree must not crash and must match the first.
+        let second = MTTypesetter.createLineForMathList(mathList, font: self.font, style: .display)
+        XCTAssertNotNil(second)
+        XCTAssertEqual(first!.width, second!.width, accuracy: 0.01)
+        XCTAssertEqual(first!.ascent, second!.ascent, accuracy: 0.01)
+        XCTAssertEqual(first!.descent, second!.descent, accuracy: 0.01)
+    }
+
     func testRealWorldExample_QuadraticFormula() throws {
         // Real-world test: quadratic formula with width constraint
         let latex = "x=\\frac{-b\\pm\\sqrt{b^{2}-4ac}}{2a}"

--- a/Tests/SwiftMathTests/MTTypesetterTests.swift
+++ b/Tests/SwiftMathTests/MTTypesetterTests.swift
@@ -1794,6 +1794,31 @@ final class MTTypesetterTests: XCTestCase {
                              "Accent should increase ascent")
     }
 
+    func testVecAccentDoesNotOverlapContent() throws {
+        // Regression test: \vec arrow must sit above the base letter, not overlap it.
+        // Uses the reported expression \(\vec{a} \times \vec{b}\).
+        let mathList = try XCTUnwrap(MTMathListBuilder.build(fromString: "\\vec{a} \\times \\vec{b}"))
+
+        let display = try XCTUnwrap(
+            MTTypesetter.createLineForMathList(mathList, font: self.font, style: .display)
+        )
+
+        let accentDisplays = display.subDisplays.compactMap { $0 as? MTAccentDisplay }
+        XCTAssertEqual(accentDisplays.count, 2, "Should have two \\vec accents")
+
+        for accentDisp in accentDisplays {
+            let accentee = try XCTUnwrap(accentDisp.accentee)
+            let glyphDisp = try XCTUnwrap(accentDisp.accent)
+            let glyph = try XCTUnwrap(glyphDisp.glyph)
+            var g = glyph
+            var rect = CGRect.zero
+            CTFontGetBoundingRectsForGlyphs(self.font.ctFont, .horizontal, &g, &rect, 1)
+            let arrowVisualBottom = glyphDisp.position.y + rect.minY
+            XCTAssertGreaterThanOrEqual(arrowVisualBottom, accentee.ascent,
+                "\\vec arrow should sit above the base letter, not overlap it")
+        }
+    }
+
     func testMultiCharacterArrowAccents() throws {
         // Test that multi-character arrow accents render correctly
         // This is the reported bug: arrow should be above both characters, not after the last one


### PR DESCRIPTION
# Math rendering fixes: nth-root degree, fraction spacing, \vec arrows, matrix re-typesetting

This PR collects several typesetting/rendering correctness fixes, each with regression
test coverage. All changes are self-contained and additive in behavior.

## Changes

### Radical (nth-root) degree positioning
`MTRadicalDisplay` placed the degree relative to the radical's origin only once, at
set-up time. If the radical was later repositioned (inter-element spacing, line-wrap
adjustments), the degree was left behind and drifted out of alignment. The degree
offset is now cached (`_degreeKernBefore` / `_degreeRaise`) and reapplied via a new
`updateDegreePosition()` whenever the radical moves. The cached `raise` depends only
on ascent/descent, which are fixed before the degree is set, so caching is safe.

### Inline fraction bar clearance
Text-style (inline) fractions used the small `fractionNumerator/DenominatorGapMin`,
which made the numerator and denominator hug the bar. They now use the larger
display-style clearance — matching display fractions and giving inline fractions
proper breathing room. The compact gap is preserved for the smaller script styles so
deeply nested fractions are not over-spaced.

### `\vec` (non-stretchy arrow) accent positioning
The previous `height = ascent - delta` formula collapsed the arrow onto the base
character for x-height glyphs. The arrow is now placed a positive gap above the
ascent (`ascent + upperLimitGapMin - minYCompensation`), consistent with how stretchy
arrow accents are positioned, so it no longer overlaps the letter.

### Tables treated as inner for inter-element spacing
`.table` now shares the spacing class of `.fraction`/`.inner` instead of falling
through to the no-spacing default, fixing inconsistent gaps around delimited matrices.

## Tests

- **MTTypesetterTests** — delimited matrices can be typeset repeatedly without
  crashing, and remain stable across repeated layout passes.
- **FractionBarOverlapTests** — numerator/denominator no longer overlap the bar in
  inline and display contexts.
- **MTMathUILabelLineWrappingTests** — regression coverage for mixed text + math
  line wrapping: large operators (`\sum`, `\int`) and scripted atoms (`x^{p}`)
  following text do not overflow the right edge, tall operators on continuation
  lines do not overlap the line above, script glyphs are not duplicated during
  wrap layout, and text after a scripted atom fills the remainder of the line.